### PR TITLE
Fixed executable permissions of ltex-ls and Java binaries. Added automatic activation support for .amd files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "onLanguage:quarto",
     "onLanguage:restructuredtext",
     "onLanguage:rsweave",
+    "onLanguage:amd",
     "onNotebook:*"
   ],
   "contributes": {
@@ -162,7 +163,8 @@
             "org",
             "quarto",
             "restructuredtext",
-            "rsweave"
+            "rsweave",
+            "amd"
           ],
           "markdownDescription": "%ltex.i18n.configuration.ltex.enabled.markdownDescription%",
           "examples": [

--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -515,6 +515,20 @@ export default class DependencyManager {
         this._ltexLsPath!, 'bin', (DependencyManager._isWindows
           ? 'ltex-ls-plus.bat' : 'ltex-ls-plus'));
 
+    if (!DependencyManager._isWindows) {
+      const cwd: string = this._ltexLsPath!;
+      const directories: string[] = Fs.readdirSync(cwd).filter(function (file: string) {
+        return Fs.statSync(Path.join(cwd, file)).isDirectory() && file.startsWith('jdk-');
+      });
+
+      const jdkExecutablePath: string = Path.join(
+        cwd, directories[0], 'bin', 'java'
+      );
+
+      Fs.chmodSync(ltexLsScriptPath, 0o755);
+      Fs.chmodSync(jdkExecutablePath, 0o755);    
+    }
+    
     const workspaceConfig: Code.WorkspaceConfiguration = Code.workspace.getConfiguration('ltex');
     const initialJavaHeapSize: number | undefined = workspaceConfig.get('java.initialHeapSize');
     const maximumJavaHeapSize: number | undefined = workspaceConfig.get('java.maximumHeapSize');


### PR DESCRIPTION
## Description

Two issues were addressed in this PR:

1. When using a Linux VSCode devcontainer, the executable flag for the downloaded ltex-ls and Java binaries were not set, resulting in an installation failure. This change checks whether the current system in not Windows, then uses the native chmod function to set the binary permissions to match those present in the archive files. This includes dynamically detecting the JDK path to allow for JDK updates without breaking the permission change process.
2. We make extensive use of files with the .amd extension (markdown with some extras) and found it a pain to manually activate the extension every time VSCode was opened. Since there is no configurable way to have a custom file type to auto-activate, we've included the required file type in package.json. 

## Checklist

* [X] Have you read the [guidelines on contributing code to LT<sub>E</sub>X](https://ltex-plus.github.io/ltex-plus/vscode-ltex-plus/contributing.html#how-to-contribute-code)?
* [X] Have you filled in all missing information in this pull request template?
* [X] Have you written new tests for your changes, if applicable?
* [X] Do your changes pass all [code checks](https://ltex-plus.github.io/ltex-plus/vscode-ltex-plus/contributing.html#code-checks) such as linting and tests?
