### PR TITLE
Record ltex-ls server name and version from `serverInfo`

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -14,6 +14,9 @@
   </properties>
   <body>
     <release version="15.7.0" date="upcoming">
+      <action type="add" issue="ltex-plus/ltex-ls-plus#177" due-to="Andrea Alberti (@alberti42)">
+        Record the language server name and version reported through the LSP `initialize` response (`serverInfo`, added in ltex-ls-plus#177). Falls back gracefully when connected to an older server that does not report it. Lays the groundwork for version-gating client features in the future.
+      </action>
       <action type="add" due-to="Andrea Alberti (@alberti42)">
         Accept `elisp` and `emacs-lisp` as `codeLanguageId`s alongside the existing `lisp`. Adds activation events for both IDs so the extension activates when an Elisp buffer is opened (via a third-party Emacs Lisp extension), and maps the `.el` file extension into the enabled-file-extensions set used by batch-check commands when `elisp`, `emacs-lisp`, or `lisp` is listed in `ltex.enabled`. Requires the matching server-side aliases in ltex-ls-plus.
       </action>

--- a/i18n/messages.nls.de.json
+++ b/i18n/messages.nls.de.json
@@ -15,6 +15,7 @@
 	"findingAllDocumentsInWorkspace": "Finde alle Dokumente im Arbeitsbereich ...",
 	"ltexIsChecking": "LTeX prüft ...",
 	"ltexLanguageServer": "LTeX Language Server",
+	"ltexLsReportedServerInfo": "Mit Sprachserver '{0}' Version '{1}' verbunden.",
 	"ltexLsWasAlreadyStarted": "ltex-ls wurde bereits gestarted. Es wird keine weitere Instanz gestartet.",
 	"ltexNotInitialized": "LTeX wurde aufgrund eines vorhergehenden Fehlers nicht initialisiert.",
 	"ltexReady": "LTeX bereit",

--- a/i18n/messages.nls.json
+++ b/i18n/messages.nls.json
@@ -58,6 +58,7 @@
 	"ltexIsChecking": "LTeX is checking...",
 	"ltexLanguageServer": "LTeX Language Server",
 	"ltexLsDidNotPrintExpectVersionInformation": "ltex-ls did not print expected version information to stdout.",
+	"ltexLsReportedServerInfo": "Connected to language server '{0}' version '{1}'.",
 	"ltexLsFoundIn": "ltex-ls found in '{0}'.",
 	"ltexLsInfo": "Info about ltex-ls:",
 	"ltexLsTerminatedDueToSignal": "ltex-ls terminated due to signal '{0}'.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,13 @@ export class Api {
 	public languageClient: CodeLanguageClient.LanguageClient | null = null;
 	public clientOutputChannel: LoggingOutputChannel | null = null;
 	public serverOutputChannel: LoggingOutputChannel | null = null;
+	// Name and version reported by ltex-ls-plus through the LSP `initialize`
+	// response (`serverInfo`), available since ltex-ls-plus#177. The version
+	// string is SemVer 2.0.0 compliant (e.g. "18.7.0-alpha.93+2026-05-20.g...").
+	// `null` when connected to an older server that does not report it.
+	// Intended for version-gating client features in the future.
+	public ltexLsServerName: string | null = null;
+	public ltexLsServerVersion: string | null = null;
 }
 
 let dependencyManager: DependencyManager | null = null;
@@ -51,6 +58,31 @@ async function languageClientIsReady(
 		"ltex/workspaceSpecificConfiguration",
 		workspaceConfigurationRequestHandler.handle.bind(
 			workspaceConfigurationRequestHandler,
+		),
+	);
+}
+
+function recordServerInfo(
+	languageClient: CodeLanguageClient.LanguageClient,
+	api: Api,
+): void {
+	// `initializeResult` is populated once `start()` has resolved.
+	const serverInfo: { name: string; version?: string } | undefined =
+		languageClient.initializeResult?.serverInfo;
+
+	if (serverInfo == null) {
+		api.ltexLsServerName = null;
+		api.ltexLsServerVersion = null;
+		return;
+	}
+
+	api.ltexLsServerName = serverInfo.name;
+	api.ltexLsServerVersion = serverInfo.version ?? null;
+	Logger.log(
+		i18n(
+			"ltexLsReportedServerInfo",
+			serverInfo.name,
+			serverInfo.version ?? "unknown",
 		),
 	);
 }
@@ -161,6 +193,8 @@ export async function startLanguageClient(): Promise<void> {
 	commandHandler.languageClient = languageClient;
 	commandHandler.statusBarItemManager = statusBarItemManager;
 	api.languageClient = languageClient;
+
+	recordServerInfo(languageClient, api);
 
 	return Promise.resolve();
 }


### PR DESCRIPTION
## Summary

Adds client-side support for [ltex-plus/ltex-ls-plus#177](https://github.com/ltex-plus/ltex-ls-plus/pull/177), which makes the language server report its name and version through the LSP `initialize` response (`serverInfo`).

The extension now captures `serverInfo.name` and `serverInfo.version` once the language client has started and stores them on the extension's public `Api` object. For now these are simply recorded (and logged); the intent is to use the version in the future to **gate client features based on the server version**.

## Motivation

Until now the extension had no reliable way to know the version of the *running* language server. The only version available (`DependencyManager.ltexLsVersion`) is parsed from the server's `--version` CLI output. With `serverInfo` we get the server's own self-reported version over the LSP connection, which is the natural basis for version-gating.

## What changed

- **`src/extension.ts`**
  - Added two fields to the exported `Api` class: `ltexLsServerName` and `ltexLsServerVersion` (both `string | null`).
  - Added a synchronous `recordServerInfo()` helper that reads `languageClient.initializeResult?.serverInfo` after `start()` resolves, stores the values, and logs them. Called from `startLanguageClient()`.
- **`i18n/messages.nls.json`, `i18n/messages.nls.de.json`**
  - Added the `ltexLsReportedServerInfo` log message (EN + DE).
- **`changelog.xml`**
  - Added an `add` entry to the upcoming `15.7.0` release referencing ltex-ls-plus#177.

## Backward compatibility

This is a **new addition on both sides** — neither `serverInfo` (server) nor any handling of it (client) existed before. Older servers that predate [ltex-ls-plus#177](https://github.com/ltex-plus/ltex-ls-plus/pull/177) simply don't send `serverInfo`, so the code degrades gracefully:

- `languageClient.initializeResult?.serverInfo` uses optional chaining.
- When `serverInfo` is absent, both fields are set to `null`, nothing is logged, and the extension continues normally.
- A present-but-versionless `serverInfo` is handled via `serverInfo.version ?? null`.

`recordServerInfo()` is fully synchronous and sends no request to the server, so it cannot stall the connection or crash against an older server. `null` doubles as the right sentinel for future gating ("server too old / doesn't report → unsupported").

## How to retrieve the values

- **Internally** (future feature-gating): via the module-level `api` object; a small exported accessor can expose it where needed. The version string is SemVer 2.0.0 with build metadata (e.g. `18.7.0-alpha.95+2026-06-01.gcc781b63`) and works with `semver.coerce()` / comparisons.
- **From another extension**: via the `Api` object returned by `activate()` — `api.ltexLsServerName` / `api.ltexLsServerVersion`.

## Testing

Verified against a ltex-ls-plus build that includes [ltex-ls-plus#177](https://github.com/ltex-plus/ltex-ls-plus/pull/177). The new log line appears in the **"LTeX Language Server"** output channel:

```
Connected to language server 'ltex-ls-plus' version '18.7.0-alpha.95+2026-06-01.gcc781b63'.
```

`npm run compile` (tsc) and Biome lint both pass.
